### PR TITLE
Add lambda config for cognito

### DIFF
--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -91,6 +91,20 @@ resource "aws_cognito_user_pool" "this" {
       <strong>{####}</strong>
     EOT
   }
+
+  lambda_config {
+    create_auth_challenge          = var.lambda_config.create_auth_challenge
+    custom_message                 = var.lambda_config.custom_message
+    define_auth_challenge          = var.lambda_config.define_auth_challenge
+    post_authentication            = var.lambda_config.post_authentication
+    post_confirmation              = var.lambda_config.post_confirmation
+    pre_authentication             = var.lambda_config.pre_authentication
+    pre_sign_up                    = var.lambda_config.pre_sign_up
+    pre_token_generation           = var.lambda_config.pre_token_generation
+    user_migration                 = var.lambda_config.user_migration
+    verify_auth_challenge_response = var.lambda_config.verify_auth_challenge_response
+    kms_key_id                     = var.lambda_config.kms_key_id
+  }
 }
 
 resource "aws_cognito_user_pool_client" "this" {

--- a/aws/cognito_user_pool/terraform.tf
+++ b/aws/cognito_user_pool/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+}

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -37,32 +37,20 @@ variable "lambda_config" {
   description = "Sets which lambda function to use for various cognito specializations"
   type = object(
     {
-      create_auth_challenge          = string
-      custom_message                 = string
-      define_auth_challenge          = string
-      post_authentication            = string
-      post_confirmation              = string
-      pre_authentication             = string
-      pre_sign_up                    = string
-      pre_token_generation           = string
-      user_migration                 = string
-      verify_auth_challenge_response = string
-      kms_key_id                     = string
+      create_auth_challenge          = optional(string)
+      custom_message                 = optional(string)
+      define_auth_challenge          = optional(string)
+      post_authentication            = optional(string)
+      post_confirmation              = optional(string)
+      pre_authentication             = optional(string)
+      pre_sign_up                    = optional(string)
+      pre_token_generation           = optional(string)
+      user_migration                 = optional(string)
+      verify_auth_challenge_response = optional(string)
+      kms_key_id                     = optional(string)
     }
   )
-  default = {
-    create_auth_challenge          = ""
-    custom_message                 = ""
-    define_auth_challenge          = ""
-    post_authentication            = ""
-    post_confirmation              = ""
-    pre_authentication             = ""
-    pre_sign_up                    = ""
-    pre_token_generation           = ""
-    user_migration                 = ""
-    verify_auth_challenge_response = ""
-    kms_key_id                     = ""
-  }
+  default = {}
 }
 
 variable "clients" {

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -33,6 +33,38 @@ variable "password_policy" {
   }
 }
 
+variable "lambda_config" {
+  description = "Sets which lambda function to use for various cognito specializations"
+  type = object(
+    {
+      create_auth_challenge          = string
+      custom_message                 = string
+      define_auth_challenge          = string
+      post_authentication            = string
+      post_confirmation              = string
+      pre_authentication             = string
+      pre_sign_up                    = string
+      pre_token_generation           = string
+      user_migration                 = string
+      verify_auth_challenge_response = string
+      kms_key_id                     = string
+    }
+  )
+  default = {
+    create_auth_challenge          = ""
+    custom_message                 = ""
+    define_auth_challenge          = ""
+    post_authentication            = ""
+    post_confirmation              = ""
+    pre_authentication             = ""
+    pre_sign_up                    = ""
+    pre_token_generation           = ""
+    user_migration                 = ""
+    verify_auth_challenge_response = ""
+    kms_key_id                     = ""
+  }
+}
+
 variable "clients" {
   description = "A map of user pool clients to create"
   type = map(object(


### PR DESCRIPTION
This PR adds support for `lambda_config` for cognito user pools. This defaults everything to empty (i.e. no lambdas).

See [Terraform AWS module](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool#lambda_config) for details on the existing lambda_config values.

Notably, this does not expose `custom_email_sender` and `custom_sms_sender`. Partially this is due to not having a good idea of how to expose this, and partially these values seem to be set anyway when using `terraform plan`