### PR TITLE
Switch RDS engine_version to 12 (from 12.5)

### DIFF
--- a/aws/rds/main.tf
+++ b/aws/rds/main.tf
@@ -22,7 +22,7 @@ module "rds" {
   identifier = local.instance_name
 
   engine                      = "postgres"
-  engine_version              = "12.5"
+  engine_version              = "12"
   family                      = "postgres12"
   major_engine_version        = "12"
   allow_major_version_upgrade = false


### PR DESCRIPTION
This PR alters the engine_version for RDS to "12" (instead of "12.5"). This should allow for any version of 12, and meshes well with `auto_minor_version_upgrade`. The previous value "12.5" seemed to prefer this version to the point of trying to force a downgrade from newer versions (in our case, it tried to force a downgrade from 12.7 to 12.5)