### PR TITLE
Allow for customizing new user message on cognito

### DIFF
--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -49,15 +49,9 @@ resource "aws_cognito_user_pool" "this" {
     allow_admin_create_user_only = false
 
     invite_message_template {
-      email_subject = "Your temporary password"
-      email_message = <<-EOT
-        Your username is {username} and temporary password is
-        <strong>{####}</strong>
-      EOT
-      sms_message   = <<-EOT
-        Your username is {username} and temporary password is
-        <strong>{####}</strong>
-      EOT
+      email_subject = var.create_user_messaging.email_subject
+      email_message = var.create_user_messaging.email_message
+      sms_message   = var.create_user_messaging.sms_message
     }
   }
 

--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -46,7 +46,7 @@ resource "aws_cognito_user_pool" "this" {
   }
 
   admin_create_user_config {
-    allow_admin_create_user_only = false
+    allow_admin_create_user_only = var.allow_admin_create_user_only
 
     invite_message_template {
       email_subject = var.create_user_messaging.email_subject

--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -23,6 +23,17 @@ locals {
     "email_verified",
     "phone_number_verified"
   ])
+  standard_messaging = defaults(var.create_user_messaging, {
+    email_subject = "Your temporary password"
+    email_message = <<-EOT
+      Your username is {username} and temporary password is
+      <strong>{####}</strong>
+    EOT
+    sms_message   = <<-EOT
+      Your username is {username} and temporary password is
+      <strong>{####}</strong>
+    EOT
+  })
 }
 
 resource "aws_cognito_user_pool" "this" {
@@ -49,9 +60,9 @@ resource "aws_cognito_user_pool" "this" {
     allow_admin_create_user_only = var.allow_admin_create_user_only
 
     invite_message_template {
-      email_subject = var.create_user_messaging.email_subject
-      email_message = var.create_user_messaging.email_message
-      sms_message   = var.create_user_messaging.sms_message
+      email_subject = local.standard_messaging.email_subject
+      email_message = local.standard_messaging.email_message
+      sms_message   = local.standard_messaging.sms_message
     }
   }
 

--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -23,7 +23,7 @@ locals {
     "email_verified",
     "phone_number_verified"
   ])
-  standard_messaging = defaults(var.create_user_messaging, {
+  create_user_messaging = defaults(var.create_user_messaging, {
     email_subject = "Your temporary password"
     email_message = <<-EOT
       Your username is {username} and temporary password is
@@ -60,9 +60,9 @@ resource "aws_cognito_user_pool" "this" {
     allow_admin_create_user_only = var.allow_admin_create_user_only
 
     invite_message_template {
-      email_subject = local.standard_messaging.email_subject
-      email_message = local.standard_messaging.email_message
-      sms_message   = local.standard_messaging.sms_message
+      email_subject = local.create_user_messaging.email_subject
+      email_message = local.create_user_messaging.email_message
+      sms_message   = local.create_user_messaging.sms_message
     }
   }
 

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -74,3 +74,25 @@ variable "groups" {
   ))
   default = {}
 }
+
+variable "create_user_messaging" {
+  description = "Provides basic customized messaging for new accounts"
+  type = object(
+    {
+      email_subject = optional(string)
+      email_message = optional(string)
+      sms_message   = optional(string)
+    }
+  )
+  default = {
+    email_subject = "Your temporary password"
+    email_message = <<-EOT
+      Your username is {username} and temporary password is
+      <strong>{####}</strong>
+    EOT
+    sms_message   = <<-EOT
+      Your username is {username} and temporary password is
+      <strong>{####}</strong>
+    EOT
+  }
+}

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -96,3 +96,9 @@ variable "create_user_messaging" {
     EOT
   }
 }
+
+variable "allow_admin_create_user_only" {
+  description = "Indicates if users should not be able to self register. False = User can self register"
+  type        = string
+  default     = false
+}

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -84,17 +84,6 @@ variable "create_user_messaging" {
       sms_message   = optional(string)
     }
   )
-  default = {
-    email_subject = "Your temporary password"
-    email_message = <<-EOT
-      Your username is {username} and temporary password is
-      <strong>{####}</strong>
-    EOT
-    sms_message   = <<-EOT
-      Your username is {username} and temporary password is
-      <strong>{####}</strong>
-    EOT
-  }
 }
 
 variable "allow_admin_create_user_only" {


### PR DESCRIPTION
This PR exposes the functionality around basic email templates when a new user is created. This is used to provide a temporary password for the user to user to log in.