### PR TITLE
Fix changes detected in empty lambda_config

### DIFF
--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -97,18 +97,22 @@ resource "aws_cognito_user_pool" "this" {
     EOT
   }
 
-  lambda_config {
-    create_auth_challenge          = var.lambda_config.create_auth_challenge
-    custom_message                 = var.lambda_config.custom_message
-    define_auth_challenge          = var.lambda_config.define_auth_challenge
-    post_authentication            = var.lambda_config.post_authentication
-    post_confirmation              = var.lambda_config.post_confirmation
-    pre_authentication             = var.lambda_config.pre_authentication
-    pre_sign_up                    = var.lambda_config.pre_sign_up
-    pre_token_generation           = var.lambda_config.pre_token_generation
-    user_migration                 = var.lambda_config.user_migration
-    verify_auth_challenge_response = var.lambda_config.verify_auth_challenge_response
-    kms_key_id                     = var.lambda_config.kms_key_id
+  dynamic "lambda_config" {
+    for_each = length(compact(values(var.lambda_config))) > 0 ? [var.lambda_config] : []
+
+    content {
+      create_auth_challenge          = lambda_config.value.create_auth_challenge
+      custom_message                 = lambda_config.value.custom_message
+      define_auth_challenge          = lambda_config.value.define_auth_challenge
+      post_authentication            = lambda_config.value.post_authentication
+      post_confirmation              = lambda_config.value.post_confirmation
+      pre_authentication             = lambda_config.value.pre_authentication
+      pre_sign_up                    = lambda_config.value.pre_sign_up
+      pre_token_generation           = lambda_config.value.pre_token_generation
+      user_migration                 = lambda_config.value.user_migration
+      verify_auth_challenge_response = lambda_config.value.verify_auth_challenge_response
+      kms_key_id                     = lambda_config.value.kms_key_id
+    }
   }
 }
 


### PR DESCRIPTION
When the `lambda_config` is empty (all `null` values), Terraform removes it entirely from the saved state. So when it gets run again with an empty `lambda_config` specified, it detects this as a change and requires update even though there isn't an actual change. This fixes the issue by only including the `lambda_config` if there is a non-null value within the variable object