### PR TITLE
allow ses configuration for cognito

### DIFF
--- a/aws/cognito_user_pool/main.tf
+++ b/aws/cognito_user_pool/main.tf
@@ -97,6 +97,18 @@ resource "aws_cognito_user_pool" "this" {
     EOT
   }
 
+  dynamic "email_configuration" {
+    for_each = length(compact(values(var.email_config))) > 0 ? [var.email_config] : []
+
+    content {
+      configuration_set      = email_configuration.value.configuration_set
+      email_sending_account  = email_configuration.value.email_sending_account
+      from_email_address     = email_configuration.value.from_email_address
+      reply_to_email_address = email_configuration.value.reply_to_email_address
+      source_arn             = email_configuration.value.source_arn
+    }
+  }
+
   dynamic "lambda_config" {
     for_each = length(compact(values(var.lambda_config))) > 0 ? [var.lambda_config] : []
 

--- a/aws/cognito_user_pool/variables.tf
+++ b/aws/cognito_user_pool/variables.tf
@@ -92,3 +92,17 @@ variable "allow_admin_create_user_only" {
   type        = string
   default     = false
 }
+
+variable "email_config" {
+  description = "Sets email configuration for cognito"
+  type = object (
+    {
+      configuration_set      = optional(string)
+      email_sending_account  = optional(string)
+      from_email_address     = optional(string)
+      reply_to_email_address = optional(string)
+      source_arn             = optional(string)
+    }
+  )
+  default = {}
+}


### PR DESCRIPTION
This PR just exposes the [email_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool#email_configuration) options for cognito.