### PR TITLE
ci: automatic releases with semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - v*
 jobs:
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+
+      # Configuration for semantic-release is in `.releaserc.yml`
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release@18.0.0
+
+      # At this point the release is done if it was time for a release. Steps
+      # below this point perform a fast-forward merge from main to the latest
+      # major version branch if we just tagged a release.
+
+      - name: Get major version of tag for the current commit in main
+        id: get_tag
+        run: |
+          export MAJOR_VERSION=$(git tag --points-at HEAD | grep -oE '^v[0-9]+' | sort | tail -n1)
+          echo "::set-output name=major_version::$MAJOR_VERSION"
+
+      - name: Update latest major version branch
+        if: startsWith(steps.get_tag.outputs.major_version, 'v')
+        run: |
+          git switch ${{ steps.get_tag.outputs.major_version }} || git switch -c ${{ steps.get_tag.outputs.major_version }}
+          git merge --ff-only main ${{ steps.get_tag.outputs.major_version }}
+          git push origin ${{ steps.get_tag.outputs.major_version }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,12 @@
+name: "PR title matches conventional commit format"
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v2.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,7 @@
+branches:
+  - "v([0-9])" # Maintenance branches are of the form v1, v2, etc.
+  - main
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - "@semantic-release/github"

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,5 +1,5 @@
 branches:
-  - "v([0-9])" # Maintenance branches are of the form v1, v2, etc.
+  - "v([0-9]+)" # Maintenance branches are of the form v1, v2, etc.
   - main
 plugins:
   - "@semantic-release/commit-analyzer"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
 # terraform-modules
+
 Composable Terraform modules for provisioning infrastructure stacks
+
+## Automatic Releases
+
+This repository is configured to publish releases automatically using
+semantic-release when changes are merged to `main`. Releases are posted on
+Github with automatically-generated changelogs. Here is what you need to know.
+
+### Special commit message format
+
+Automatic releases include automatically-generated changelogs. To make this work
+it is important to write commit messages in the
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+A CI action is included that will check that your PR title matches that format.
+Make sure to "Squash & Merge" PRs to ensure that the PR title is used as the git
+commit message for your change.
+
+Briefly the first line of a commit message must begin with one of the prefixes,
+`fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`,
+`perf:`, `test:`
+
+A commit message may include a "trailer" (a paragraph at the end of the message
+preceded by a blank line) that begins with the string `BREAKING CHANGE:`
+
+### When releases are triggered
+
+On a merge to `main` a release is created if and only if a new feature, bug fix,
+or breaking change has been introduced since the latest release. Whether one of
+these has been introduced is determined by parsing specially-formatted commit
+messages. If the first line of a commit begins with `feat:` that means the
+change introduces a feature; `fix:` means the change includes a bug fix. Any
+commit with a `BREAKING CHANGE:` trailer indicates a breaking change.
+
+### How version numbers are calculated
+
+The version number for a new release is based on the number of the latest
+release, and the types of changes that have been made since that release.
+According to the convention of semantic version numbering a bug fix causes the
+patch number to be incremented, a feature increments the minor version number,
+and a breaking change increments the major version number.
+
+### Tracking major version numbers
+
+When you source a module using Terraform you provide a "ref" to use. You can fix
+your Terraform configuration to a specific release version number. But it might
+be more convenient to get the latest release from a given major version. For
+example,
+
+```tf
+module "cognito_agent_pool" {
+  source = "github.com/Originate/terraform-modules//aws/cognito_user_pool?ref=v1"
+                                                # Track the latest v1 release ^
+}
+```
+
+The release workflow for this repository automatically updates the latest major
+version branch to point to the latest release to make this possible. If
+a breaking change is merged which causes a major version bump then the workflow
+will automatically create a new major version branch, and leave the previous
+major version branch pointing to the last release with the matching major
+version.
+
+### Publishing maintenance releases
+
+Maybe the latest release is `v2.1.0`, but you want to publish a new `v1` release
+with fixes for users tracking the `v1` branch. You can do this by merging
+changes to the `v1` branch instead of to `main`.
+
+Do not merge changes to a major version branch if it is the latest major version
+branch! It is important to be able to fast-forward merge `main` into the latest
+major version branch.
+
+Do not merge breaking changes into a major version branch. If you do semantic
+release will refuse to create a release, and you will have to rewrite the
+history of that branch to remove the breaking change to get releases working
+again.
+
+### Updating semantic-release settings
+
+Settings are in `.releaserc.yml`. You probably won't need to change this; but
+there it is in any case.


### PR DESCRIPTION
This change introduces an automatic release process which creates tags, Github releases, and automatically updates a major version branch on release so that we can continue to use the same strategy to track the latest v1 release. See my changes to the readme for more details.

This change requires replacing the `v1` tag with a `v1` branch. I checked the Terraform docs, and a branch works as well as a tag for sourcing a specific ref.

The semantic release workflow works best if we limit PRs to "Squash & Merge". The issue is that we need commit messages to be specially-formated. I included an action that checks PR titles for the correct format - if you squash & merge then the PR message becomes the squashed commit message. If we allow other PR merge options it is harder to check that we are getting commits with correctly-formatted messages.