### PR TITLE
ci: skip merge to major version branch when running workflow from same branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,9 @@ jobs:
           echo "::set-output name=major_version::$MAJOR_VERSION"
 
       - name: Update latest major version branch
-        if: startsWith(steps.get_tag.outputs.major_version, 'v')
+        if: |
+          startsWith(steps.get_tag.outputs.major_version, 'v') &&
+          github.ref == 'refs/heads/main'
         run: |
           git switch ${{ steps.get_tag.outputs.major_version }} || git switch -c ${{ steps.get_tag.outputs.major_version }}
           git merge --ff-only main ${{ steps.get_tag.outputs.major_version }}


### PR DESCRIPTION
This is a small fix to the automated release flow. If you merge a change into a major version branch, like `v1`, to publish a maintenance release the workflow tried to merge that branch into itself which fails. This change skips the merge step if the current branch is not `main`.