### PR TITLE
feat: Add support for SQS

### DIFF
--- a/aws/sqs/main.tf
+++ b/aws/sqs/main.tf
@@ -1,0 +1,35 @@
+locals {
+  # This helps avoid queue names ending in "-" or "-.fifo"
+  given_queue_name = var.queue_name == "" ? "" : "-${var.queue_name}"
+  # All fifo queues must end in .fifo, per AWS rules
+  queue_suffix    = var.is_fifo == true ? ".fifo" : ""
+  full_queue_name = "${var.stack}-${var.env}${local.given_queue_name}${local.queue_suffix}"
+}
+
+resource "aws_sqs_queue" "this" {
+  name                        = local.full_queue_name
+  fifo_queue                  = var.is_fifo
+  content_based_deduplication = var.content_based_deduplication
+  receive_wait_time_seconds   = var.receive_wait_time_seconds
+  visibility_timeout_seconds  = var.visibility_timeout_seconds
+}
+
+resource "aws_sqs_queue_policy" "this" {
+  queue_url = aws_sqs_queue.this.id
+
+  policy = jsonencode(
+    {
+      Version : "2008-10-17"
+      Id : "__default_policy_ID"
+      Statement : [
+        {
+          Sid : "__owner_statement"
+          Effect : "Allow"
+          Principal : "*"
+          Action : "sqs:*"
+          Resource : "${aws_sqs_queue.this.arn}"
+        }
+      ]
+    }
+  )
+}

--- a/aws/sqs/outputs.tf
+++ b/aws/sqs/outputs.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  value = aws_sqs_queue.this.arn
+}
+
+output "full_queue_name" {
+  value = aws_sqs_queue.this.name
+}

--- a/aws/sqs/terraform.tf
+++ b/aws/sqs/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  experiments = [module_variable_optional_attrs]
+}

--- a/aws/sqs/variables.tf
+++ b/aws/sqs/variables.tf
@@ -1,0 +1,38 @@
+variable "stack" {
+  description = "The name of the stack"
+  type        = string
+}
+
+variable "env" {
+  description = "The name of the environment"
+  type        = string
+}
+
+variable "queue_name" {
+  description = "The shorthand name of the queue. The full queue name can be retrieved as an output. Note that an empty string is still a valid queue name."
+  type        = string
+}
+
+variable "visibility_timeout_seconds" {
+  description = "The amount of time allowed to the processor to process a message before it is declared failed. Defaults to 30 seconds."
+  type        = number
+  default     = 30
+}
+
+variable "receive_wait_time_seconds" {
+  description = "The time to wait when polling for new messages. Use 0 for immediate response. Longer values are preferred. AWS recommends a maximum of 20 seconds."
+  type        = number
+  default     = 5
+}
+
+variable "is_fifo" {
+  description = "Specifies if this queue should be a FIFO queue, which would preserve message ordering. Defaults to true."
+  type        = bool
+  default     = true
+}
+
+variable "content_based_deduplication" {
+  description = "Specifies if this queue should use content-based deduplication. Must be false if using a standard (non-fifo) queue. Defaults to true"
+  type        = bool
+  default     = true
+}

--- a/aws/sqs/versions.tf
+++ b/aws/sqs/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for SQS deployments. This tries to be opinionated in the following ways:

* Defaults to long polling (10 seconds)
* Sets the visibility timeout to 30 seconds (which is the normal AWS default, and seems sensible for most usecases)
* Tries to enforce a shorthand queue name
* Prefers fifo queues that use content-based deduplication

This also provides the generated name of the queue as an output, which will typically be needed by any deployment.